### PR TITLE
Add a distributed debounce function

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,42 +10,48 @@
 
 > [!NOTE]  
 > **This project is in the Experimental Stage.**
-> 
+>
 > We declare this project experimental to set clear expectations for your usage. There could be known or unknown bugs, the API could evolve, or the project could be discontinued if it does not find community adoption. While we cannot provide professional support for experimental projects, we’d be happy to hear from you if you see value in this project!
 
-`@upstash/lock` offers a distributed lock implementation using Upstash Redis.
+`@upstash/lock` offers a distributed lock and debounce implementation using Upstash Redis.
 
 ### Disclaimer
 
-Please use this lock implementation for efficiency purposes; for example to avoid doing an expensive work more than once or to perform a task _mostly_ once in a best-effort manner. 
-Do not use it to guarantee correctness of your system; such as leader-election or for the tasks requiring _exactly_ once execution. 
+Please use this lock implementation for efficiency purposes; for example to avoid doing an expensive work more than once or to perform a task _mostly_ once in a best-effort manner.
+Do not use it to guarantee correctness of your system; such as leader-election or for the tasks requiring _exactly_ once execution.
 
 Upstash Redis uses async replication between replicas, and a lock can be acquired by multiple clients in case of a crash or network partition. Please read the post [How to do distributed locking](https://martin.kleppmann.com/2016/02/08/how-to-do-distributed-locking.html) by Martin Kleppman to learn more about the topic.
 
 ### Quick Start
 
 NPM
+
 ```bash
 npm install @upstash/lock
 ```
+
 PNPM
+
 ```bash
 pnpm add @upstash/lock
 ```
+
 Bun
+
 ```bash
 bun add @upstash/lock
 ```
 
-### Demo
+### Locking Demo
+
 To see a demo of the lock in action, visit [https://lock-upstash.vercel.app](https://lock-upstash.vercel.app)
 
 To create the Redis instance, you can use the `Redis.fromEnv()` method to use an Upstash Redis instance from environment variables. More options can be found [here](https://github.com/upstash/upstash-redis#quick-start).
 
-### Example Usage
+### Lock Example Usage
 
 ```typescript
-import { Lock } from '@upstash/lock';
+import { Lock } from "@upstash/lock";
 import { Redis } from "@upstash/redis";
 
 async function handleOperation() {
@@ -64,7 +70,36 @@ async function handleOperation() {
 }
 ```
 
-### API
+### Debounce Example Usage
+
+```typescript
+import { Lock } from "@upstash/lock";
+import { Redis } from "@upstash/redis";
+import { expensiveWork } from "my-app";
+
+const debouncedFunction = new Debounce({
+  id: "unique-function-id",
+  redis: Redis.fromEnv(),
+
+  // Wait time of 1 second
+  // The debounced function will only be called once per second across all instances
+  wait: 1000,
+
+  // Callback function to be debounced
+  callback: (arg) => {
+    doExpensiveWork(arg);
+  },
+});
+
+// This example function is called by our app to trigger work we want to only happen once per wait period
+async function triggerExpensiveWork(arg: string) {
+  // Call the debounced function
+  // This will only call the callback function once per wait period
+  await debouncedFunction.call(arg)
+}
+```
+
+### Lock API
 
 #### `Lock`
 
@@ -72,15 +107,16 @@ async function handleOperation() {
 new Lock({
   id: string,
   redis: Redis, // ie. Redis.fromEnv(), new Redis({...})
-  lease?: number, // default: 10000 ms
-  retry?: {
-    attempts?: number, // default: 3
-    delay?: number, // default: 100 ms
+  lease: number, // default: 10000 ms
+  retry: {
+    attempts: number, // default: 3
+    delay: number, // default: 100 ms
   },
-})
+});
 ```
 
 #### `Lock#acquire`
+
 Attempts to acquire the lock. Returns `true` if the lock is acquired, `false` otherwise.
 
 You can pass a `config` object to override the default `lease` and `retry` options.
@@ -90,6 +126,7 @@ async acquire(config?: LockAcquireConfig): Promise<boolean>
 ```
 
 #### `Lock#release`
+
 Attempts to release the lock. Returns `true` if the lock is released, `false` otherwise.
 
 ```typescript
@@ -97,6 +134,7 @@ async release(): Promise<boolean>
 ```
 
 #### `Lock#extend`
+
 Attempts to extend the lock lease. Returns `true` if the lock lease is extended, `false` otherwise.
 
 ```typescript
@@ -104,14 +142,41 @@ async extend(amt: number): Promise<boolean>
 ```
 
 #### `Lock#getStatus`
+
 Returns whether the lock is `ACQUIRED` or `FREE`.
 
 ```typescript
 async getStatus(): Promise<LockStatus>
 ```
 
-| Option           | Default Value | Description                                                 |
-|------------------|---------------|-------------------------------------------------------------|
+| Option           | Default Value | Description                                                                       |
+| ---------------- | ------------- | --------------------------------------------------------------------------------- |
 | `lease`          | `10000`       | The lease duration in milliseconds. After this expires, the lock will be released |
-| `retry.attempts` | `3`           | The number of attempts to acquire the lock.                |
-| `retry.delay`    | `100`         | The delay between attempts in milliseconds.                 |
+| `retry.attempts` | `3`           | The number of attempts to acquire the lock.                                       |
+| `retry.delay`    | `100`         | The delay between attempts in milliseconds.                                       |
+
+### Debounce API
+
+#### `Debounce`
+
+Creates a new debounced function.
+
+```typescript
+new Debounce({
+  id: string,
+  redis: Redis, // ie. Redis.fromEnv(), new Redis({...})
+  wait: number, // default: 1000 ms
+  callback: (...arg: any[]) => any // The function to be debounced
+});
+```
+
+#### `Debounce#call`
+
+Calls the debounced function. The function will only be called once per `wait` period.
+When called there is a best-effort guarantee that the function will be called once per `wait` period.
+
+Note: Due to the implementation of the debounce, there is always a delay of `wait` milliseconds before the function is called (even if the callback is not triggered when you use the call function).
+
+```typescript
+async call(...args: any[]): Promise<void>
+```

--- a/src/debounce.test.ts
+++ b/src/debounce.test.ts
@@ -1,26 +1,25 @@
 import { expect, test } from "bun:test";
 import { Redis } from "@upstash/redis";
-import { DistributedDebounce } from "./debounce";
+import { Debounce } from "./debounce";
 
 function getUniqueFunctionId() {
   return `debounce-test-${Math.random().toString(36).substr(2, 9)}`;
 }
 
 test("Debounced function is only called once per wait time", async () => {
-  
   // Initialize a counter
   // We will use this to check how many times the debounced function is called
   let count = 0;
 
   const uniqueId = getUniqueFunctionId();
-  const debouncedFunction = new DistributedDebounce({
+  const debouncedFunction = new Debounce({
     id: uniqueId,
     redis: Redis.fromEnv(),
 
     // Wait time of 1 second
     // The debounced function will only be called once per second
     wait: 1000,
-    
+
     // Callback function to be debounced
     callback: () => {
       // Increment the counter
@@ -39,12 +38,11 @@ test("Debounced function is only called once per wait time", async () => {
   expect(count).toBe(1);
 });
 
-
 test("Debounced function with arguments is called correctly", async () => {
   let coolWord = "";
 
   const uniqueId = getUniqueFunctionId();
-  const debouncedFunction = new DistributedDebounce({
+  const debouncedFunction = new Debounce({
     id: uniqueId,
     redis: Redis.fromEnv(),
     wait: 1000,
@@ -64,4 +62,40 @@ test("Debounced function with arguments is called correctly", async () => {
 
   // Our coolWord should be one of the words we passed to the debounced function
   expect(words).toContain(coolWord);
+});
+
+test("Debounced async functions trigger correctly", async () => {
+  // Initialize a counter
+  // We will use this to check how many times the debounced function is called
+  let count = 0;
+
+  const uniqueId = getUniqueFunctionId();
+  const debouncedFunction = new Debounce({
+    id: uniqueId,
+    redis: Redis.fromEnv(),
+
+    // Wait time of 1 second
+    // The debounced function will only be called once per second
+    wait: 1000,
+
+    // Callback function to be debounced
+    callback: async () => {
+
+      // wait for 1 second
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
+      // Increment the counter
+      count++;
+    },
+  });
+
+  for (let i = 0; i < 10; i++) {
+    debouncedFunction.call();
+  }
+
+  // Wait 2 seconds
+  await new Promise((resolve) => setTimeout(resolve, 3000));
+
+  // The debounced function should only be called once
+  expect(count).toBe(1);
 });

--- a/src/debounce.test.ts
+++ b/src/debounce.test.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "bun:test";
+import { Redis } from "@upstash/redis";
+import { DistributedDebounce } from "./debounce";
+
+function getUniqueFunctionId() {
+  return `debounce-test-${Math.random().toString(36).substr(2, 9)}`;
+}
+
+test("Debounced function is only called once per wait time", async () => {
+  
+  // Initialize a counter
+  // We will use this to check how many times the debounced function is called
+  let count = 0;
+
+  const uniqueId = getUniqueFunctionId();
+  const debouncedFunction = new DistributedDebounce({
+    id: uniqueId,
+    redis: Redis.fromEnv(),
+
+    // Wait time of 1 second
+    // The debounced function will only be called once per second
+    wait: 1000,
+    
+    // Callback function to be debounced
+    callback: () => {
+      // Increment the counter
+      count++;
+    },
+  });
+
+  for (let i = 0; i < 10; i++) {
+    debouncedFunction.call();
+  }
+
+  // Wait 2 seconds
+  await new Promise((resolve) => setTimeout(resolve, 2000));
+
+  // The debounced function should only be called once
+  expect(count).toBe(1);
+});
+
+
+test("Debounced function with arguments is called correctly", async () => {
+  let coolWord = "";
+
+  const uniqueId = getUniqueFunctionId();
+  const debouncedFunction = new DistributedDebounce({
+    id: uniqueId,
+    redis: Redis.fromEnv(),
+    wait: 1000,
+    callback: (word: string) => {
+      coolWord = word;
+    },
+  });
+
+  const words = ["Upstash", "Is", "A", "Serverless", "Redis", "Database", "Provider"];
+
+  for (const word of words) {
+    debouncedFunction.call(word);
+  }
+
+  // Wait 2 seconds
+  await new Promise((resolve) => setTimeout(resolve, 2000));
+
+  // Our coolWord should be one of the words we passed to the debounced function
+  expect(words).toContain(coolWord);
+});

--- a/src/debounce.test.ts
+++ b/src/debounce.test.ts
@@ -53,7 +53,7 @@ test("Debounced function with arguments is called correctly", async () => {
     },
   });
 
-  const words = ["Upstash", "Is", "A", "Serverless", "Redis", "Database", "Provider"];
+  const words = ["Upstash", "Is", "A", "Serverless", "Database", "Provider"];
 
   for (const word of words) {
     debouncedFunction.call(word);

--- a/src/debounce.ts
+++ b/src/debounce.ts
@@ -1,0 +1,48 @@
+import { DistributedDebounceConfig } from "./types";
+
+/**
+ * A distributed debounce utility that ensures a function is only called once within a specified wait time.
+ * Using a Redis instance, this utility can be used across multiple instances of an application
+ * to debounce a function call.
+ */
+export class DistributedDebounce {
+  private readonly config: DistributedDebounceConfig;
+  private DEFAULT_WAIT_MS: number = 1000;
+
+  constructor(config: DistributedDebounceConfig) {
+    this.config = {
+      redis: config.redis,
+      id: config.id,
+      wait: config.wait ?? this.DEFAULT_WAIT_MS,
+      callback: config.callback,
+    };
+  }
+
+  /**
+   * Calls the callback function after the specified wait time has passed.
+   * If the function is called multiple times within the wait time, the callback will only be called once.
+   * This is useful for debouncing a function across multiple instances of an application.
+   */
+  public async call(...args: any[]) {
+    // Increment the counter
+    const thisTaskIncr = await this.config.redis.incr(this.config.id);
+
+    // Wait for a delay
+    await new Promise((resolve) => setTimeout(resolve, this.config.wait));
+
+    // Get the current counter
+    const currentTaskIncr = await this.config.redis.get(this.config.id);
+
+    // If the counter has changed, it means another task has called the function
+    // So we should not call the callback
+    // We should only run the callback if the counter has not changed in the last wait time
+    // This is to ensure that the callback is only called once per wait time
+    if (thisTaskIncr !== currentTaskIncr) {
+      return;
+    }
+
+    // We were the last task to increment the counter
+    // So we can call the callback
+    await this.config.callback(...args);
+  }
+}

--- a/src/debounce.ts
+++ b/src/debounce.ts
@@ -1,15 +1,15 @@
-import { DistributedDebounceConfig } from "./types";
+import { DebounceConfig } from "./types";
 
 /**
  * A distributed debounce utility that ensures a function is only called once within a specified wait time.
  * Using a Redis instance, this utility can be used across multiple instances of an application
  * to debounce a function call.
  */
-export class DistributedDebounce {
-  private readonly config: DistributedDebounceConfig;
+export class Debounce {
+  private readonly config: DebounceConfig;
   private DEFAULT_WAIT_MS: number = 1000;
 
-  constructor(config: DistributedDebounceConfig) {
+  constructor(config: DebounceConfig) {
     this.config = {
       redis: config.redis,
       id: config.id,
@@ -23,7 +23,7 @@ export class DistributedDebounce {
    * If the function is called multiple times within the wait time, the callback will only be called once.
    * This is useful for debouncing a function across multiple instances of an application.
    */
-  public async call(...args: any[]) {
+  public async call(...args: any[]): Promise<void> {
     // Increment the counter
     const thisTaskIncr = await this.config.redis.incr(this.config.id);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,7 +79,7 @@ export type LockCreateConfig = {
 
 export type LockStatus = "ACQUIRED" | "FREE";
 
-export type DistributedDebounceConfig = {
+export type DebounceConfig = {
   /**
    * Upstash Redis client instance for locking operations.
    */
@@ -98,5 +98,5 @@ export type DistributedDebounceConfig = {
   /**
    * The callback function to execute after the wait time.
    */
-  callback: (...args: any[]) => void;
+  callback: (...args: any[]) => any;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -78,3 +78,25 @@ export type LockCreateConfig = {
 };
 
 export type LockStatus = "ACQUIRED" | "FREE";
+
+export type DistributedDebounceConfig = {
+  /**
+   * Upstash Redis client instance for locking operations.
+   */
+  redis: Redis;
+
+  /**
+   * Unique identifier associated with the lock.
+   */
+  id: string;
+
+  /**
+   * Duration (in ms) for which to wait before executing the callback.
+   */
+  wait: number;
+
+  /**
+   * The callback function to execute after the wait time.
+   */
+  callback: (...args: any[]) => void;
+};


### PR DESCRIPTION
# Distributed Debounce

Hey :wave:, here is a PR to include a distributed debounce function utilising redis. I thought this repo would be a good home for this functionality as it "feels" like a similar usecase to locking. 

## Usage
```
  // Initialize a counter
  // We will use this to check how many times the debounced function is called
  let count = 0;

  const debouncedFunction = new DistributedDebounce({
    id: "my-debounced-function",
    redis: Redis.fromEnv(),

    // Wait time of 1 second
    // The debounced function will only be called once per second
    wait: 1000,
    
    // Callback function to be debounced
    callback: () => {
      // Increment the counter
      count++;
    },
  });

  // Simulate the function being called 10 times quickly
  for (let i = 0; i < 10; i++) {
    debouncedFunction.call();
  }

  // Wait 2 seconds
  await new Promise((resolve) => setTimeout(resolve, 2000));

  // The debounced function should only be called once
  expect(count).toBe(1);
  ```

## Why this PR?

At Execify.ai we use the upstash/lock package a lot, we have also needed to make sure that work is only done once across our distributed application.

To handle this we have been using Upstash to implement a distributed debounce system which I thought I would take the time to share.